### PR TITLE
Downgrade ZMK, fixes #8

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -7,7 +7,7 @@ manifest:
   projects:
     - name: zmk
       remote: petejohanson
-      revision: core/move-to-zephyr-4-1
+      revision: afda1561bf9aeb4cb74f709acc8bf61f809450ea
       import: app/west.yml
   self:
     path: config


### PR DESCRIPTION
The upgrade from Zephyr 3.5 to Zephyr 4.1 from ZMK brought up some issues regarding the usb bus, and the Quacken Zero with a Sparkfun Promicro rp2040 board stopped working as a result (see #8 ). This PR pins ZMK’s version to the latest revision that still works for this board.

The reason we don’t just stay on ZMK 0.3 is that the Quacken Flex requires Zephyr >4.0 to have the I2C driver for it’s io-expander, and we’d like to have the same version of the firmware on all of our boards.

further research is needed to understand why the usb port is unreliable on the Flex 25.11 (see #7 , this PR seems to help ?) and why it doesn’t work at all on the Flex 25.12. Once we have more info, I’ll submit a bug report / PR upstream to try and fix all usb related issues.