### PR TITLE
XOSC startup delay

### DIFF
--- a/boards/ergonautes/quacken_flex/quacken_flex.dts
+++ b/boards/ergonautes/quacken_flex/quacken_flex.dts
@@ -245,3 +245,8 @@ zephyr_udc0: &usbd {
         };
     };
 };
+
+&xosc {
+    // XXX: Ensure the communication works even if the XOSC starts up slowly.
+    startup-delay-multiplier = <64>;
+};


### PR DESCRIPTION
Partially fixes #7 

This is the same value (64) as in the `rp2040-hal` crate used by Keyberon — which works fine with the Flex 25.12.