### PR TITLE
use the Hardware Model v2 draft branch

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -7,7 +7,7 @@ manifest:
   projects:
     - name: zmk
       remote: petejohanson
-      revision: afda1561bf9aeb4cb74f709acc8bf61f809450ea
+      revision: core/move-to-hwmv2-extension-approach
       import: app/west.yml
   self:
     path: config


### PR DESCRIPTION
#8 will be fixed when the upstream branch is merged (which is part of the ZMK 0.4 milestone, afaik).

Until that, this branch can be used to ensure our firmware still works with the ongoing ZMK development effort.