### PR TITLE
Flex 26 01

### DIFF
--- a/boards/ergonautes/quacken_flex/quacken_flex.dts
+++ b/boards/ergonautes/quacken_flex/quacken_flex.dts
@@ -173,7 +173,7 @@ rp2040_gpio: &gpio0 {
 
 &i2c0 {
     status = "okay";
-    clock-frequency = <I2C_BITRATE_FAST>;
+    clock-frequency = <I2C_BITRATE_STANDARD>;
     pinctrl-0 = <&i2c0_custom>;
     pinctrl-names = "default";
 


### PR DESCRIPTION
The new Flex 26.01 board comes with a different flash memory chip than previous versions. The protocol is the exact same, but the total capacity went down from 16 MB to 2 MB. It should still be more than enough for a complex keymap, and this new firmware remains fully backwards compatible, though the detailed capacity has been documented in the code, just in case.