### PR TITLE
Syntax highlighting

### DIFF
--- a/keymaps/quacken.keymap
+++ b/keymaps/quacken.keymap
@@ -1,4 +1,4 @@
-// nano: syntax=c
+// -*- mode:c -*-
 // Selenium keymap for the Quacken: https://github.com/OneDeadKey/selenium
 
 


### PR DESCRIPTION
Neovim has a nice syntax highlighting for DTS files, but GitHub has not.

So let’s use a fake Emacs modeline, so GH highlights the keymap file as C (= decent fallback), and Neovim keeps highlighting it as DTS.