### PR TITLE
NumNav: X_ALL, X_REDO and Shift+Space

### DIFF
--- a/keymaps/quacken.keymap
+++ b/keymaps/quacken.keymap
@@ -131,7 +131,7 @@
         &trans  &kp ESC  &kp HOME &kp UP   &kp END   &kp PG_UP    &none     S_N7  S_N8  S_N9  S_FSLH  &trans
         &trans  X_ALL    &kp LEFT &kp DOWN &kp RIGHT &kp PG_DN    S_MINUS   S_N4  S_N5  S_N6  S_N0    &trans
         &trans  X_UNDO   X_CUT    X_COPY   X_PASTE   X_REDO       S_COMMA   S_N1  S_N2  S_N3  S_DOT   &trans
-               &kp CAPSLOCK  &lt FUNCTION_LAYER DEL  &kp LS(TAB)  &kp ESCAPE  &lt FUNCTION_LAYER LS(SPACE)  &lkp BASE_LAYER RALT
+               &kp CAPSLOCK  &sc FUNCTION_LAYER DEL  &kp LS(TAB)  &kp ESCAPE  &lt FUNCTION_LAYER LS(SPACE)  &lkp BASE_LAYER RALT
       >;
     };
 


### PR DESCRIPTION
Small fixes for the `NavNum` layer:
- there’s already a `CapsLock` on the left thumb, so we can use `NavNum`+`A` as `X_ALL` (select all)
- there’s already a `Shift`+`Tab` on the left thumb, so we can use `NavNum`+`B` as `X_REDO`
- pressing the right Space key in `NavNum` now does `Shift`+`Space` to be consistent with `NumRow`

I suggest we land #27 first, then this patch.