### PR TITLE
Wip: conditionnally enabled HRMs on every layer 

### DIFF
--- a/keymaps/aliases.h
+++ b/keymaps/aliases.h
@@ -1,4 +1,5 @@
 #include <dt-bindings/zmk/keys.h>
+#include "../hold_taps.dtsi"
 
 // PC / Mac
 
@@ -53,6 +54,6 @@
 
 // Non-Alpha Actions
 
-#define X_SHTAB &kp RS(TAB)
+#define X_SHTAB HRM_CTL(RS(TAB))
 #define X_PREV  &kp LA(LEFT)
 #define X_NEXT  &kp LA(RIGHT)

--- a/keymaps/aliases/ergol.h
+++ b/keymaps/aliases/ergol.h
@@ -1,4 +1,5 @@
 #include <dt-bindings/zmk/keys.h>
+#include "../hold_taps.dtsi"
 
 /**
  * Action Combos
@@ -11,8 +12,8 @@
 #define X_REDO  &kp CMD(P)
 
 #define X_CLOSE &kp CMD(T)
-#define X_SAVE  &kp CMD(S)
-#define X_ALL   &kp CMD(A)
+#define X_SAVE  HRM_GUI(CMD(S))
+#define X_ALL   HRM_SFT(CMD(A))
 
 /**
  * Arsenik Symbols:
@@ -34,16 +35,16 @@
 #define S_GRAVE &kp GRAVE
 
 // second row
-#define S_LBRC  &kp LBRC
-#define S_LPAR  &kp RA(S)
-#define S_RPAR  &kp RA(D)
-#define S_RBRC  &kp RBRC
+#define S_LBRC  HRM_SFT(LBRC)
+#define S_LPAR  HRM_GUI(RA(S))
+#define S_RPAR  HRM_CTL(RA(D))
+#define S_RBRC  HRM_ALT(RBRC)
 #define S_EQUAL &kp EQUAL
 #define S_BSLH  &kp BSLH
-#define S_PLUS  &kp PLUS
-#define S_MINUS &kp C
-#define S_FSLH  &kp MINUS
-#define S_DQT   &kp DQT
+#define S_PLUS  HRM_ALT(PLUS)
+#define S_MINUS HRM_CTL(C)
+#define S_FSLH  HRM_GUI(MINUS)
+#define S_DQT   HRM_SFT(DQT)
 
 // third row
 #define S_TILDE &kp TILDE

--- a/keymaps/hold_taps.dtsi
+++ b/keymaps/hold_taps.dtsi
@@ -33,7 +33,7 @@
 #endif
 
 #if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
-  #define HRM_CTL(kc) &hrm LCTL (kc)
+  #define HRM_CTL(kc) &ihrm LCTL (kc)
   #define HRM_ALT(kc) &hrm LALT (kc)
   #define HRM_GUI(kc) &hrm LGUI (kc)
 #else
@@ -43,7 +43,7 @@
 #endif
 
 #ifdef HRM_SHIFT
-  #define HRM_SFT(kc) &hrm LSFT (kc)
+  #define HRM_SFT(kc) &ihrm LSFT (kc)
 #else
   #define HRM_SFT(kc) &kp (kc)
 #endif
@@ -170,6 +170,18 @@
       quick-tap-ms = <QUICK_TAP>;
       flavor = "tap-preferred";
       bindings = <&kp>, <&kp>;
+    };
+    // Same as hrm, but hold action is held immediately, and disabled before
+    // the tapaction. Handy when used with a mouse, but causes quick taps of
+    // the modifier when typing (can cause issues with Alt and Gui)
+    ihrm: instant_homerow_mods {
+      compatible = "zmk,behavior-hold-tap";
+      #binding-cells = <2>;
+      tapping-term-ms = <TAPPING_TERM>;
+      quick-tap-ms = <QUICK_TAP>;
+      flavor = "tap-preferred";
+      bindings = <&kp>, <&kp>;
+      hold-while-undecided;
     };
     sc: space_cadet { // same as lt, but with hold-preferred
       compatible = "zmk,behavior-hold-tap";

--- a/keymaps/hold_taps.dtsi
+++ b/keymaps/hold_taps.dtsi
@@ -33,29 +33,29 @@
 #endif
 
 #if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
-  #define HRM_S &hrm LGUI S
-  #define HRM_D &hrm LCTL D
-  #define HRM_F &hrm LALT F
-  #define HRM_J &hrm LALT J
-  #define HRM_K &hrm RCTL K
-  #define HRM_L &hrm RGUI L
+  #define HRM_CTL(kc) &hrm LCTL (kc)
+  #define HRM_ALT(kc) &hrm LALT (kc)
+  #define HRM_GUI(kc) &hrm LGUI (kc)
 #else
-  #define HRM_S &kp S
-  #define HRM_D &kp D
-  #define HRM_F &kp F
-  #define HRM_J &kp J
-  #define HRM_K &kp K
-  #define HRM_L &kp L
+  #define HRM_CTL(kc) &kp (kc)
+  #define HRM_ALT(kc) &kp (kc)
+  #define HRM_GUI(kc) &kp (kc)
 #endif
 
 #ifdef HRM_SHIFT
-  #define HRM_A    &hrm LSHIFT A
-  #define HRM_SEMI &hrm RSHIFT SEMI
+  #define HRM_SFT(kc) &hrm LSFT (kc)
 #else
-  #define HRM_A    &kp A
-  #define HRM_SEMI &kp SEMI
+  #define HRM_SFT(kc) &kp (kc)
 #endif
 
+#define HRM_A    HRM_SFT(A)
+#define HRM_S    HRM_GUI(S)
+#define HRM_D    HRM_CTL(D)
+#define HRM_F    HRM_ALT(F)
+#define HRM_J    HRM_ALT(J)
+#define HRM_K    HRM_CTL(K)
+#define HRM_L    HRM_GUI(L)
+#define HRM_SEMI HRM_SFT(SEMI)
 
 /**
  * Thumb Keys

--- a/keymaps/quacken.keymap
+++ b/keymaps/quacken.keymap
@@ -127,10 +127,9 @@
     vim_nav_layer: vim_nav_layer {
       display-name = "VimNav";
       bindings = <
-        &trans  &kp CAPS X_CLOSE  X_PREV   X_NEXT    &none        &kp HOME &kp PG_DN &kp PG_UP &kp END   &kp DEL &trans
-        &trans  X_ALL    X_SAVE   X_SHTAB  &kp TAB   &none        &kp LEFT &kp DOWN  &kp UP    &kp RIGHT &none   &trans
-        &trans  X_UNDO   X_CUT    X_COPY   X_PASTE   X_REDO       &none    &none     &none     &none     &none   &trans
-        &kp CAPSLOCK  &lt FUNCTION_LAYER DEL  &mo NUM_ROW_LAYER   &trans   &mo FUNCTION_LAYER  &EZ_LSK(RALT)
+        &trans  &kp CAPS X_CLOSE  X_PREV   X_NEXT       &none        &kp HOME &kp PG_DN     &kp PG_UP   &kp END        &kp DEL    &trans
+        &trans  X_ALL    X_SAVE   X_SHTAB  HRM_CTL(TAB) &none        &kp LEFT HRM_ALT(DOWN) HRM_ALT(UP) HRM_ALT(RIGHT) &kp LSHIFT &trans
+        &trans  X_UNDO   X_CUT    X_COPY   X_PASTE      X_REDO       &none    &none         &none       &none          &none      &trans
       >;
     };
 
@@ -140,9 +139,9 @@
     num_nav_layer: num_nav_layer {
       display-name = "NumNav";
       bindings = <
-        &trans  &kp ESC        &kp HOME      &kp UP        &kp END        &kp PG_UP     &to NUM_LOCK_LAYER S_N7          S_N8          S_N9          S_FSLH         &trans
-        &trans  HRM_SFT(X_ALL) HRM_GUI(LEFT) HRM_CTL(DOWN) HRM_ALT(RIGHT) &kp PG_DN     S_MINUS            HRM_SFT(S_N4) HRM_SFT(S_N5) HRM_SFT(S_N6) HRM_SFT(S_N0)  &trans
-        &trans  X_UNDO         X_CUT         X_COPY        X_PASTE        X_REDO        S_COMMA            S_N1          S_N2          S_N3          S_DOT          &trans
+        &trans  &kp ESC &kp HOME      &kp UP        &kp END        &kp PG_UP    &to NUM_LOCK_LAYER S_N7  S_N8  S_N9  S_FSLH  &trans
+        &trans  X_ALL   HRM_GUI(LEFT) HRM_CTL(DOWN) HRM_ALT(RIGHT) &kp PG_DN    S_MINUS            S_N4  S_N5  S_N6  S_N0    &trans
+        &trans  X_UNDO  X_CUT         X_COPY        X_PASTE        X_REDO       S_COMMA            S_N1  S_N2  S_N3  S_DOT   &trans
                &kp CAPSLOCK  &sc FUNCTION_LAYER DEL  &kp LS(TAB)  &kp ESCAPE  &lt FUNCTION_LAYER LS(SPACE)  &EZ_LSK(RALT)
       >;
     };
@@ -153,10 +152,10 @@
     num_row_layer: num_row_layer {
       display-name = "NumRow";
       bindings = <
-        &trans  &kp RS(N1)  &kp RS(N2)  &kp RS(N3)  &kp RS(N4)  &kp RS(N5)       &kp LS(N6) &kp LS(N7)  &kp LS(N8)  &kp LS(N9)  &kp LS(N0)  &trans
-        &trans  HRM_SFT(N1) HRM_SFT(N2) HRM_SFT(N3) HRM_SFT(N4) &kp N5           &kp N6     HRM_SFT(N7) HRM_SFT(N8) HRM_SFT(N9) HRM_SFT(N0) &trans
-        &trans  &none       &none       &none       &none       &none            S_MINUS    S_COMMA     S_DOT       S_COLON     S_FSLH      &trans
-                                          &trans  &kp RS(SPACE) &trans           &trans  &kp LS(SPACE) &kp RALT
+        &trans  &kp RS(N1)  &kp RS(N2)  &kp RS(N3)  &kp RS(N4)  &kp RS(N5)        &kp LS(N6)  &kp LS(N7)  &kp LS(N8)  &kp LS(N9)  &kp LS(N0)  &trans
+        &trans  HRM_SFT(N1) HRM_SFT(N2) HRM_SFT(N3) HRM_SFT(N4) HRM_SFT(N5)       HRM_SFT(N6) HRM_SFT(N7) HRM_SFT(N8) HRM_SFT(N9) HRM_SFT(N0) &trans
+        &trans  &none       &none       &none       &none       &none             S_MINUS     S_COMMA     S_DOT       S_COLON     S_FSLH      &trans
+                                      &trans  &kp RS(SPACE) &trans           &trans  &kp LS(SPACE) &kp RALT
       >;
     };
 
@@ -166,10 +165,10 @@
     function_layer: function_layer {
       display-name = "Function";
       bindings = <
-        &trans  &kp F1       &kp F2       &kp F3       &kp F4       &none         &none &kp C_PREV    &kp C_VOL_UP    &kp C_BRI_UP       &kp SLCK       &trans
-        &trans  HRM_SFT(F5)  HRM_GUI(F6)  HRM_CTL(F7)  HRM_ALT(F8)  &none         &none HRM_ALT(C_PP) HRM_CTL(C_MUTE) HRM_GUI(C_AL_LOCK) HRM_SFT(PSCRN) &trans
-        &trans  &kp F9       &kp F10      &kp F11      &kp F12      &none         &none &kp C_NEXT    &kp C_VOL_DN    &kp C_BRI_DN       &kp INS        &trans
-                                                    &trans  &trans  &bootloader   &sys_reset  &trans  &studio_unlock
+        &trans  &kp F1  &kp F2  &kp F3  &kp F4  &none         &none &kp C_PREV    &kp C_VOL_UP    &kp C_BRI_UP       &kp SLCK       &trans
+        &trans  &kp F5  &kp F6  &kp F7  &kp F8  &none         &none HRM_ALT(C_PP) HRM_CTL(C_MUTE) HRM_GUI(C_AL_LOCK) HRM_SFT(PSCRN) &trans
+        &trans  &kp F9  &kp F10 &kp F11 &kp F12 &none         &none &kp C_NEXT    &kp C_VOL_DN    &kp C_BRI_DN       &kp INS        &trans
+                                &trans  &trans  &bootloader   &sys_reset  &trans  &studio_unlock
       >;
     };
   };

--- a/keymaps/quacken.keymap
+++ b/keymaps/quacken.keymap
@@ -140,9 +140,9 @@
     num_nav_layer: num_nav_layer {
       display-name = "NumNav";
       bindings = <
-        &trans  &kp ESC  &kp HOME &kp UP   &kp END   &kp PG_UP    &to NUM_LOCK_LAYER S_N7  S_N8  S_N9  S_FSLH  &trans
-        &trans  X_ALL    &kp LEFT &kp DOWN &kp RIGHT &kp PG_DN    S_MINUS            S_N4  S_N5  S_N6  S_N0    &trans
-        &trans  X_UNDO   X_CUT    X_COPY   X_PASTE   X_REDO       S_COMMA            S_N1  S_N2  S_N3  S_DOT   &trans
+        &trans  &kp ESC        &kp HOME      &kp UP        &kp END        &kp PG_UP     &to NUM_LOCK_LAYER S_N7          S_N8          S_N9          S_FSLH         &trans
+        &trans  HRM_SFT(X_ALL) HRM_GUI(LEFT) HRM_CTL(DOWN) HRM_ALT(RIGHT) &kp PG_DN     S_MINUS            HRM_SFT(S_N4) HRM_SFT(S_N5) HRM_SFT(S_N6) HRM_SFT(S_N0)  &trans
+        &trans  X_UNDO         X_CUT         X_COPY        X_PASTE        X_REDO        S_COMMA            S_N1          S_N2          S_N3          S_DOT          &trans
                &kp CAPSLOCK  &sc FUNCTION_LAYER DEL  &kp LS(TAB)  &kp ESCAPE  &lt FUNCTION_LAYER LS(SPACE)  &EZ_LSK(RALT)
       >;
     };
@@ -153,10 +153,10 @@
     num_row_layer: num_row_layer {
       display-name = "NumRow";
       bindings = <
-        &trans  &kp RS(N1) &kp RS(N2) &kp RS(N3) &kp RS(N4) &kp RS(N5)       &kp LS(N6) &kp LS(N7) &kp LS(N8) &kp LS(N9) &kp LS(N0) &trans
-        &trans  &kp N1     &kp N2     &kp N3     &kp N4     &kp N5           &kp N6     &kp N7     &kp N8     &kp N9     &kp N0     &trans
-        &trans  &none      &none      &none      &none      &none            S_MINUS    S_COMMA    S_DOT      S_COLON    S_FSLH     &trans
-                                      &trans  &kp RS(SPACE) &trans           &trans  &kp LS(SPACE) &kp RALT
+        &trans  &kp RS(N1)  &kp RS(N2)  &kp RS(N3)  &kp RS(N4)  &kp RS(N5)       &kp LS(N6) &kp LS(N7)  &kp LS(N8)  &kp LS(N9)  &kp LS(N0)  &trans
+        &trans  HRM_SFT(N1) HRM_SFT(N2) HRM_SFT(N3) HRM_SFT(N4) &kp N5           &kp N6     HRM_SFT(N7) HRM_SFT(N8) HRM_SFT(N9) HRM_SFT(N0) &trans
+        &trans  &none       &none       &none       &none       &none            S_MINUS    S_COMMA     S_DOT       S_COLON     S_FSLH      &trans
+                                          &trans  &kp RS(SPACE) &trans           &trans  &kp LS(SPACE) &kp RALT
       >;
     };
 
@@ -166,10 +166,10 @@
     function_layer: function_layer {
       display-name = "Function";
       bindings = <
-        &trans  &kp F1  &kp F2  &kp F3  &kp F4  &none         &none &kp C_PREV     &kp C_VOL_UP     &kp C_BRI_UP        &kp SLCK           &trans
-        &trans  &kp F5  &kp F6  &kp F7  &kp F8  &none         &none &hrm LALT C_PP &hrm RCTL C_MUTE &hrm RGUI C_AL_LOCK &hrm LSHIFT PSCRN  &trans
-        &trans  &kp F9  &kp F10 &kp F11 &kp F12 &none         &none &kp C_NEXT     &kp C_VOL_DN     &kp C_BRI_DN        &kp INS            &trans
-                                &trans  &trans  &bootloader   &sys_reset  &trans  &studio_unlock
+        &trans  &kp F1       &kp F2       &kp F3       &kp F4       &none         &none &kp C_PREV    &kp C_VOL_UP    &kp C_BRI_UP       &kp SLCK       &trans
+        &trans  HRM_SFT(F5)  HRM_GUI(F6)  HRM_CTL(F7)  HRM_ALT(F8)  &none         &none HRM_ALT(C_PP) HRM_CTL(C_MUTE) HRM_GUI(C_AL_LOCK) HRM_SFT(PSCRN) &trans
+        &trans  &kp F9       &kp F10      &kp F11      &kp F12      &none         &none &kp C_NEXT    &kp C_VOL_DN    &kp C_BRI_DN       &kp INS        &trans
+                                                    &trans  &trans  &bootloader   &sys_reset  &trans  &studio_unlock
       >;
     };
   };


### PR DESCRIPTION
Opening this PR as a draft, as I’m not sure about the current implementation, to be honest. What I did in this PR, was to add macros to help define home-row-mods, and those macros would expand to a `&hrm` if HRMs are enabled or to a `&kp` if they aren’t.

This implementation has however multiple issues : 
- it’s verbose, some lines grow up to 150 characters long
- it’s not very explicit : since some symbols (like `X_ALL`) are defined in a seperate file with the `&kp` directly inside, we have to change those definitions here, and not in the keymap.
- the coupling is really bad : aliases are now partially defined depending on where they are placed on the keymap. Some characters (like the `+`), get their HRM due to their placement on the `symbols` layer, but since this is globally defined, it also has it on the `num_lock` layer (where that doesn’t really make sense).

So yeah, we *really shouldn’t* merge this as is, but I’m kind of out of ideas to make it better, but I think there is some decent stuff in it (despite it overall being a mess). If anyone has a better idea, I’m all ears.