### PR TITLE
feat: Dead key behavior

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,6 @@ indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 # max_line_length = 100
+
+[*.c]
+indent_size = 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,3 @@
 if ((NOT CONFIG_ZMK_SPLIT) OR CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
-    target_sources(app PRIVATE src/behaviors/behavior_dead_key.c)
+  target_sources(app PRIVATE src/behaviors/behavior_dead_key.c)
 endif() # ((NOT CONFIG_ZMK_SPLIT) OR CONFIG_ZMK_SPLIT_ROLE_CENTRAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+if ((NOT CONFIG_ZMK_SPLIT) OR CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+    target_sources(app PRIVATE src/behaviors/behavior_dead_key.c)
+endif() # ((NOT CONFIG_ZMK_SPLIT) OR CONFIG_ZMK_SPLIT_ROLE_CENTRAL)

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,4 @@
+config ZMK_BEHAVIOR_DEAD_KEY
+    bool
+    default y
+    depends on DT_HAS_ZMK_BEHAVIOR_DEAD_KEY_ENABLED

--- a/Kconfig
+++ b/Kconfig
@@ -1,4 +1,4 @@
 config ZMK_BEHAVIOR_DEAD_KEY
-    bool
-    default y
-    depends on DT_HAS_ZMK_BEHAVIOR_DEAD_KEY_ENABLED
+  bool
+  default y
+  depends on DT_HAS_ZMK_BEHAVIOR_DEAD_KEY_ENABLED

--- a/build
+++ b/build
@@ -8,9 +8,9 @@ IFS=" "
 # comment out the following line to disable USB logging
 USB_LOGGING="-S zmk-usb-logging"
 
-# comment out the following lines to disable ZMK Studio support
-ZMK_STUDIO_SNIPPET="-S studio-rpc-usb-uart"
-ZMK_STUDIO_CMAKE="-DCONFIG_ZMK_STUDIO=y"
+# # comment out the following lines to disable ZMK Studio support
+# ZMK_STUDIO_SNIPPET="-S studio-rpc-usb-uart"
+# ZMK_STUDIO_CMAKE="-DCONFIG_ZMK_STUDIO=y"
 
 # comment out the following line to enable incremental builds
 PRISTINE="-p"
@@ -52,7 +52,7 @@ esac
 
 # ensure we have a symlink to a proper ZMK setup
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-ZMK_APP_DIR=$SCRIPT_DIR/zmk/app
+ZMK_APP_DIR=$SCRIPT_DIR/zmk_upstream/app
 if [ ! -d $ZMK_APP_DIR ]; then
 	echo "Expecting a 'zmk' symlink to your local ZMK/Zephyr setup. Aborting."
 	exit 1

--- a/build
+++ b/build
@@ -8,9 +8,9 @@ IFS=" "
 # comment out the following line to disable USB logging
 USB_LOGGING="-S zmk-usb-logging"
 
-# # comment out the following lines to disable ZMK Studio support
-# ZMK_STUDIO_SNIPPET="-S studio-rpc-usb-uart"
-# ZMK_STUDIO_CMAKE="-DCONFIG_ZMK_STUDIO=y"
+# comment out the following lines to disable ZMK Studio support
+ZMK_STUDIO_SNIPPET="-S studio-rpc-usb-uart"
+ZMK_STUDIO_CMAKE="-DCONFIG_ZMK_STUDIO=y"
 
 # comment out the following line to enable incremental builds
 PRISTINE="-p"
@@ -52,7 +52,7 @@ esac
 
 # ensure we have a symlink to a proper ZMK setup
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-ZMK_APP_DIR=$SCRIPT_DIR/zmk_upstream/app
+ZMK_APP_DIR=$SCRIPT_DIR/zmk/app
 if [ ! -d $ZMK_APP_DIR ]; then
 	echo "Expecting a 'zmk' symlink to your local ZMK/Zephyr setup. Aborting."
 	exit 1

--- a/dts/bindings/behaviors/dead-key.yaml
+++ b/dts/bindings/behaviors/dead-key.yaml
@@ -8,6 +8,6 @@ description: >
 include: one_param.yaml
 
 properties:
-  dead-keycode:
+  dead-key:
     type: int
     required: true

--- a/dts/bindings/behaviors/dead-key.yaml
+++ b/dts/bindings/behaviors/dead-key.yaml
@@ -2,8 +2,9 @@ compatible: "zmk,behavior-dead-key"
 
 description: >
   Dead Key Behavior
-  prefix a key press with an unshifted-keycode, to more easilly and reliably
-  use dead keys on the host layout to write more complex symbols.
+  Press a non-modified dead key before the target key.
+  This ensures the dead key is always applied without any modifier, even if
+  Shift or Ctrl or Cmd are pressed while the target key is tapped.
 
 include: one_param.yaml
 

--- a/dts/bindings/behaviors/dead-key.yaml
+++ b/dts/bindings/behaviors/dead-key.yaml
@@ -1,0 +1,13 @@
+compatible: "zmk,behavior-dead-key"
+
+description: >
+  Dead Key Behavior
+  prefix a key press with an unshifted-keycode, to more easilly and reliably
+  use dead keys on the host layout to write more complex symbols.
+
+include: one_param.yaml
+
+properties:
+  dead-keycode:
+    type: int
+    required: true

--- a/dts/bindings/behaviors/dead-key.yaml
+++ b/dts/bindings/behaviors/dead-key.yaml
@@ -2,7 +2,7 @@ compatible: "zmk,behavior-dead-key"
 
 description: >
   Dead Key Behavior
-  Press a non-modified dead key before the target key.
+  Tap a non-modified dead key before the target key.
   This ensures the dead key is always applied without any modifier, even if
   Shift or Ctrl or Cmd are pressed while the target key is tapped.
 

--- a/keymaps/extra_layers/ergol_hummingbird.dtsi
+++ b/keymaps/extra_layers/ergol_hummingbird.dtsi
@@ -66,6 +66,7 @@
       >;
     };
 
+    // This layer is ignored (and useless) if ENABLE_FANCY_DEAD_KEYS is defined
     shifted_one_dead_key {
       display-name = "1dkShift";
       bindings = <

--- a/keymaps/extra_layers/ergol_hummingbird.dtsi
+++ b/keymaps/extra_layers/ergol_hummingbird.dtsi
@@ -1,6 +1,5 @@
 #define ODK_LAYER        EXTRA_LAYERS_START_INDEX
-#define ODK_SHIFT_LAYER (EXTRA_LAYERS_START_INDEX + 1)
-#define EXTRA_SYM_LAYER (EXTRA_LAYERS_START_INDEX + 2)
+#define EXTRA_SYM_LAYER (EXTRA_LAYERS_START_INDEX + 1)
 
 // Override the base layer to replace Ergo‑L’s OneDeadKey
 &base_layer {
@@ -34,13 +33,12 @@
       mods      = <(MOD_LSFT|MOD_RSFT)>;
       keep-mods = <(MOD_LSFT|MOD_RSFT)>;
     };
-  };
 
-  macros {
-    // Macro to tap Ergo‑L’s ODK before the specified key
-    DEAD_KEY(odk, &kp O)
-    // Same as `odk`, but adds Shift to the specified key
-    DEAD_KEY_SHIFT(odks, &kp O)
+    odk: odk {
+      compatible = "zmk,behavior-dead-key";
+      #binding-cells = <1>;
+      dead-keycode = <O>;
+    };
   };
 
   // Extra layers defined specifically for this keymap.
@@ -54,17 +52,7 @@
         &trans  &odk Q  &odk W  &odk E  &odk R  &kp Z      &odk N  &kp Y    &odk I     &odk O   &odk P    &trans
         &trans  &odk A  &odk S  &odk D  &odk F  &kp B      &odk H  &odk J   &odk K     &odk L   &odk SEMI &trans
         &trans  &odk Q  &odk Z  &odk C  &odk V  &trans     &trans  &kp FSLH &odk COMMA &odk DOT &odk P    &trans
-           &EZ_SL(ODK_SHIFT_LAYER)  &odk SPACE  &trans     &trans  &odk SPACE  &trans
-      >;
-    };
-
-    shifted_one_dead_key {
-      display-name = "1dkShift";
-      bindings = <
-        &trans   &odks Q  &odks W  &odks E  &odks R  &kp LS(Z)      &odks N  &kp LS(Y)    &odks I     &odks O   &odks P    &trans
-        &trans   &odks A  &odks S  &odks D  &odks F  &kp LS(B)      &odks H  &odks J      &odks K     &odks L   &odks SEMI &trans
-        &trans   &odks Q  &odks Z  &odks C  &odks V  &trans         &trans   &kp LS(FSLH) &odks COMMA &odks DOT &odks P    &trans
-                            &trans   &odks SPACE  &trans      &trans   &odks SPACE  &trans
+                        &EZ_SK(LSHIFT)  &trans  &trans     &trans  &odk SPACE  &trans
       >;
     };
 

--- a/keymaps/extra_layers/ergol_hummingbird.dtsi
+++ b/keymaps/extra_layers/ergol_hummingbird.dtsi
@@ -40,7 +40,7 @@
     odk: odk {
       compatible = "zmk,behavior-dead-key";
       #binding-cells = <1>;
-      dead-keycode = <O>;
+      dead-key = <O>;
     };
   #else
     // Macro to tap Ergo‑L’s ODK before the specified key

--- a/keymaps/extra_layers/ergol_hummingbird.dtsi
+++ b/keymaps/extra_layers/ergol_hummingbird.dtsi
@@ -1,5 +1,6 @@
 #define ODK_LAYER        EXTRA_LAYERS_START_INDEX
-#define EXTRA_SYM_LAYER (EXTRA_LAYERS_START_INDEX + 1)
+#define ODK_SHIFT_LAYER (EXTRA_LAYERS_START_INDEX + 1)
+#define EXTRA_SYM_LAYER (EXTRA_LAYERS_START_INDEX + 2)
 
 // Override the base layer to replace Ergo‑L’s OneDeadKey
 &base_layer {
@@ -34,11 +35,20 @@
       keep-mods = <(MOD_LSFT|MOD_RSFT)>;
     };
 
+  #ifdef ENABLE_FANCY_DEAD_KEYS
+    #define SHIFT_KEY &EZ_SK(LSHIFT)
     odk: odk {
       compatible = "zmk,behavior-dead-key";
       #binding-cells = <1>;
       dead-keycode = <O>;
     };
+  #else
+    // Macro to tap Ergo‑L’s ODK before the specified key
+    DEAD_KEY(odk, &kp O)
+    #define SHIFT_KEY &EZ_SL(ODK_SHIFT_LAYER)
+  #endif
+    // Same as `odk`, but adds Shift to the specified key
+    DEAD_KEY_SHIFT(odks, &kp O)
   };
 
   // Extra layers defined specifically for this keymap.
@@ -52,7 +62,17 @@
         &trans  &odk Q  &odk W  &odk E  &odk R  &kp Z      &odk N  &kp Y    &odk I     &odk O   &odk P    &trans
         &trans  &odk A  &odk S  &odk D  &odk F  &kp B      &odk H  &odk J   &odk K     &odk L   &odk SEMI &trans
         &trans  &odk Q  &odk Z  &odk C  &odk V  &trans     &trans  &kp FSLH &odk COMMA &odk DOT &odk P    &trans
-                        &EZ_SK(LSHIFT)  &trans  &trans     &trans  &odk SPACE  &trans
+                             SHIFT_KEY  &trans  &trans     &trans  &odk SPACE  &trans
+      >;
+    };
+
+    shifted_one_dead_key {
+      display-name = "1dkShift";
+      bindings = <
+        &trans   &odks Q  &odks W  &odks E  &odks R  &kp LS(Z)      &odks N  &kp LS(Y)    &odks I     &odks O   &odks P    &trans
+        &trans   &odks A  &odks S  &odks D  &odks F  &kp LS(B)      &odks H  &odks J      &odks K     &odks L   &odks SEMI &trans
+        &trans   &odks Q  &odks Z  &odks C  &odks V  &trans         &trans   &kp LS(FSLH) &odks COMMA &odks DOT &odks P    &trans
+                            &trans   &odks SPACE  &trans      &trans   &odks SPACE  &trans
       >;
     };
 

--- a/keymaps/settings.h
+++ b/keymaps/settings.h
@@ -24,6 +24,9 @@
 // #define KB_EMULATION_ERGOL            // assumes the host is in QWERTY-intl or AZERTY
 // #define KB_EMULATION_QWERTY_LAFAYETTE // assumes the host is in QWERTY-intl or AZERTY
 
+// Uncomment the following line to opt-in to experimental custom dead-key behavior
+// #define ENABLE_FANCY_DEAD_KEYS
+
 // Uncomment the following line if using a Mac:
 
 // #define MACOS

--- a/src/behaviors/behavior_dead_key.c
+++ b/src/behaviors/behavior_dead_key.c
@@ -21,12 +21,12 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
 
 struct behavior_dead_key_config {
-    uint32_t dead_keycode;
+    uint32_t dead_key;
 };
 
 struct behavior_dead_key_data {
     uint32_t position;
-    uint32_t dead_keycode;
+    uint32_t dead_key;
     bool is_down;
 };
 
@@ -41,7 +41,7 @@ static int on_dead_key_binding_pressed(
 
     struct zmk_behavior_binding kp_binding = {
         .behavior_dev = "key_press",
-        .param1 = cfg->dead_keycode,
+        .param1 = cfg->dead_key,
     };
 
     const zmk_mod_flags_t mods_before = zmk_hid_get_explicit_mods();
@@ -51,7 +51,7 @@ static int on_dead_key_binding_pressed(
 
     active_dead_key = (struct behavior_dead_key_data) {
         .position = event.position,
-        .dead_keycode = cfg->dead_keycode,
+        .dead_key = cfg->dead_key,
         .is_down = true,
     };
 
@@ -69,7 +69,7 @@ static int on_dead_key_binding_released(
 ) {
     struct zmk_behavior_binding kp_binding = {
         .behavior_dev = "key_press",
-        .param1 = active_dead_key.dead_keycode,
+        .param1 = active_dead_key.dead_key,
     };
 
     if (active_dead_key.is_down) {
@@ -101,7 +101,7 @@ static int dead_key_position_state_changed_listener(const zmk_event_t *eh) {
 
     struct zmk_behavior_binding kp_binding = {
         .behavior_dev = "key_press",
-        .param1 = active_dead_key.dead_keycode,
+        .param1 = active_dead_key.dead_key,
     };
 
     struct zmk_behavior_binding_event event = {
@@ -120,7 +120,7 @@ static int dead_key_position_state_changed_listener(const zmk_event_t *eh) {
 
 #define DEAD_KEY_INST(n)                                                      \
     static struct behavior_dead_key_config behavior_dead_key_config_##n = {   \
-        .dead_keycode = DT_INST_PROP(n, dead_keycode)                         \
+        .dead_key = DT_INST_PROP(n, dead_key)                                 \
     };                                                                        \
                                                                               \
     BEHAVIOR_DT_INST_DEFINE(                                                  \

--- a/src/behaviors/behavior_dead_key.c
+++ b/src/behaviors/behavior_dead_key.c
@@ -3,6 +3,7 @@
  * Press a non-modified dead key before the target key.
  * This ensures the dead key is always applied without any modifier, even if
  * Shift or Ctrl or Cmd are pressed while the target key is tapped.
+ */
 
 #define DT_DRV_COMPAT zmk_behavior_dead_key
 

--- a/src/behaviors/behavior_dead_key.c
+++ b/src/behaviors/behavior_dead_key.c
@@ -1,0 +1,138 @@
+/*
+ * Dead Key Behavior
+ * prefix a key press with an unshifted-keycode, to more easilly and reliably
+ * use dead keys on the host layout to write more complex symbols.
+ */
+
+#define DT_DRV_COMPAT zmk_behavior_dead_key
+
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+#include <drivers/behavior.h>
+#include <dt-bindings/zmk/modifiers.h>
+#include <zmk/event_manager.h>
+#include <zmk/events/position_state_changed.h>
+#include <zmk/hid.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+#include <zmk/behavior.h>
+
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+
+struct behavior_dead_key_config {
+    uint32_t dead_keycode;
+};
+
+struct behavior_dead_key_data {
+    uint32_t position;
+    uint32_t dead_keycode;
+    bool is_down;
+};
+
+static struct behavior_dead_key_data active_dead_key;
+
+static int on_dead_key_binding_pressed(
+    struct zmk_behavior_binding *binding,
+    struct zmk_behavior_binding_event event
+) {
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    const struct behavior_dead_key_config *cfg = dev->config;
+
+    struct zmk_behavior_binding kp_binding = {
+        .behavior_dev = "key_press",
+        .param1 = cfg->dead_keycode,
+    };
+
+    const zmk_mod_flags_t mods_before = zmk_hid_get_explicit_mods();
+    zmk_hid_masked_modifiers_set(MOD_LSFT | MOD_RSFT);
+    zmk_behavior_invoke_binding(&kp_binding, event, true);
+    zmk_hid_masked_modifiers_clear();
+
+    active_dead_key = (struct behavior_dead_key_data) {
+        .position = event.position,
+        .dead_keycode = cfg->dead_keycode,
+        .is_down = true,
+    };
+
+    const zmk_mod_flags_t mods_after = zmk_hid_get_explicit_mods();
+    const zmk_mod_flags_t sticky_mods = mods_before ^ mods_after;
+    kp_binding.param1 = APPLY_MODS(sticky_mods, binding->param1);
+    zmk_behavior_invoke_binding(&kp_binding, event, true);
+
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static int on_dead_key_binding_released(
+    struct zmk_behavior_binding *binding,
+    struct zmk_behavior_binding_event event
+) {
+    struct zmk_behavior_binding kp_binding = {
+        .behavior_dev = "key_press",
+        .param1 = active_dead_key.dead_keycode,
+    };
+
+    if (active_dead_key.is_down) {
+        active_dead_key.is_down = false;
+        zmk_behavior_invoke_binding(&kp_binding, event, false);
+    };
+
+    kp_binding.param1 = binding->param1;
+    zmk_behavior_invoke_binding(&kp_binding, event, false);
+
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static const struct behavior_driver_api dead_key_driver_api = {
+    .binding_pressed  = on_dead_key_binding_pressed,
+    .binding_released = on_dead_key_binding_released,
+};
+
+static int dead_key_position_state_changed_listener(const zmk_event_t *eh);
+
+ZMK_LISTENER(behavior_dead_key, dead_key_position_state_changed_listener);
+ZMK_SUBSCRIPTION(behavior_dead_key, zmk_position_state_changed);
+
+static int dead_key_position_state_changed_listener(const zmk_event_t *eh) {
+    struct zmk_position_state_changed *ev = as_zmk_position_state_changed(eh);
+    if (ev == NULL || !active_dead_key.is_down) {
+        return ZMK_EV_EVENT_BUBBLE;
+    }
+
+    struct zmk_behavior_binding kp_binding = {
+        .behavior_dev = "key_press",
+        .param1 = active_dead_key.dead_keycode,
+    };
+
+    struct zmk_behavior_binding_event event = {
+        .position = active_dead_key.position,
+        .timestamp = ev->timestamp,
+        #if IS_ENABLED(CONFIG_ZMK_SPLIT)
+        .source = ev->source,
+        #endif
+    };
+
+    zmk_behavior_invoke_binding(&kp_binding, event, false);
+    active_dead_key.is_down = false;
+
+    return ZMK_EV_EVENT_BUBBLE;
+}
+
+#define DEAD_KEY_INST(n)                                                      \
+    static struct behavior_dead_key_config behavior_dead_key_config_##n = {   \
+        .dead_keycode = DT_INST_PROP(n, dead_keycode)                         \
+    };                                                                        \
+                                                                              \
+    BEHAVIOR_DT_INST_DEFINE(                                                  \
+        n,     /* Instance Number (Automatically populated by macro) */       \
+        NULL,  /* Initialization Function */                                  \
+        NULL,  /* Power Management Device Pointer */                          \
+        NULL,  /* Behavior Data Pointer */                                    \
+        &behavior_dead_key_config_##n,  /* Behavior Configuration Pointer */  \
+        POST_KERNEL,  /* Initialization Level */                              \
+        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,  /* Device Priority */           \
+        &dead_key_driver_api);  // API struct
+
+DT_INST_FOREACH_STATUS_OKAY(DEAD_KEY_INST)
+
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/src/behaviors/behavior_dead_key.c
+++ b/src/behaviors/behavior_dead_key.c
@@ -21,71 +21,71 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
 
 struct behavior_dead_key_config {
-    uint32_t dead_keycode;
+  uint32_t dead_keycode;
 };
 
 struct behavior_dead_key_data {
-    uint32_t position;
-    uint32_t dead_keycode;
-    bool is_down;
+  uint32_t position;
+  uint32_t dead_keycode;
+  bool is_down;
 };
 
 static struct behavior_dead_key_data active_dead_key;
 
 static int on_dead_key_binding_pressed(
-    struct zmk_behavior_binding *binding,
-    struct zmk_behavior_binding_event event
+  struct zmk_behavior_binding *binding,
+  struct zmk_behavior_binding_event event
 ) {
-    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
-    const struct behavior_dead_key_config *cfg = dev->config;
+  const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+  const struct behavior_dead_key_config *cfg = dev->config;
 
-    struct zmk_behavior_binding kp_binding = {
-        .behavior_dev = "key_press",
-        .param1 = cfg->dead_keycode,
-    };
+  struct zmk_behavior_binding kp_binding = {
+    .behavior_dev = "key_press",
+    .param1 = cfg->dead_keycode,
+  };
 
-    const zmk_mod_flags_t mods_before = zmk_hid_get_explicit_mods();
-    zmk_hid_masked_modifiers_set(MOD_LSFT | MOD_RSFT);
-    zmk_behavior_invoke_binding(&kp_binding, event, true);
-    zmk_hid_masked_modifiers_clear();
+  const zmk_mod_flags_t mods_before = zmk_hid_get_explicit_mods();
+  zmk_hid_masked_modifiers_set(MOD_LSFT | MOD_RSFT);
+  zmk_behavior_invoke_binding(&kp_binding, event, true);
+  zmk_hid_masked_modifiers_clear();
 
-    active_dead_key = (struct behavior_dead_key_data) {
-        .position = event.position,
-        .dead_keycode = cfg->dead_keycode,
-        .is_down = true,
-    };
+  active_dead_key = (struct behavior_dead_key_data) {
+    .position = event.position,
+    .dead_keycode = cfg->dead_keycode,
+    .is_down = true,
+  };
 
-    const zmk_mod_flags_t mods_after = zmk_hid_get_explicit_mods();
-    const zmk_mod_flags_t sticky_mods = mods_before ^ mods_after;
-    kp_binding.param1 = APPLY_MODS(sticky_mods, binding->param1);
-    zmk_behavior_invoke_binding(&kp_binding, event, true);
+  const zmk_mod_flags_t mods_after = zmk_hid_get_explicit_mods();
+  const zmk_mod_flags_t sticky_mods = mods_before ^ mods_after;
+  kp_binding.param1 = APPLY_MODS(sticky_mods, binding->param1);
+  zmk_behavior_invoke_binding(&kp_binding, event, true);
 
-    return ZMK_BEHAVIOR_OPAQUE;
+  return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static int on_dead_key_binding_released(
-    struct zmk_behavior_binding *binding,
-    struct zmk_behavior_binding_event event
+  struct zmk_behavior_binding *binding,
+  struct zmk_behavior_binding_event event
 ) {
-    struct zmk_behavior_binding kp_binding = {
-        .behavior_dev = "key_press",
-        .param1 = active_dead_key.dead_keycode,
-    };
+  struct zmk_behavior_binding kp_binding = {
+    .behavior_dev = "key_press",
+    .param1 = active_dead_key.dead_keycode,
+  };
 
-    if (active_dead_key.is_down) {
-        active_dead_key.is_down = false;
-        zmk_behavior_invoke_binding(&kp_binding, event, false);
-    };
-
-    kp_binding.param1 = binding->param1;
+  if (active_dead_key.is_down) {
+    active_dead_key.is_down = false;
     zmk_behavior_invoke_binding(&kp_binding, event, false);
+  };
 
-    return ZMK_BEHAVIOR_OPAQUE;
+  kp_binding.param1 = binding->param1;
+  zmk_behavior_invoke_binding(&kp_binding, event, false);
+
+  return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static const struct behavior_driver_api dead_key_driver_api = {
-    .binding_pressed  = on_dead_key_binding_pressed,
-    .binding_released = on_dead_key_binding_released,
+  .binding_pressed  = on_dead_key_binding_pressed,
+  .binding_released = on_dead_key_binding_released,
 };
 
 static int dead_key_position_state_changed_listener(const zmk_event_t *eh);
@@ -94,44 +94,44 @@ ZMK_LISTENER(behavior_dead_key, dead_key_position_state_changed_listener);
 ZMK_SUBSCRIPTION(behavior_dead_key, zmk_position_state_changed);
 
 static int dead_key_position_state_changed_listener(const zmk_event_t *eh) {
-    struct zmk_position_state_changed *ev = as_zmk_position_state_changed(eh);
-    if (ev == NULL || !active_dead_key.is_down) {
-        return ZMK_EV_EVENT_BUBBLE;
-    }
-
-    struct zmk_behavior_binding kp_binding = {
-        .behavior_dev = "key_press",
-        .param1 = active_dead_key.dead_keycode,
-    };
-
-    struct zmk_behavior_binding_event event = {
-        .position = active_dead_key.position,
-        .timestamp = ev->timestamp,
-        #if IS_ENABLED(CONFIG_ZMK_SPLIT)
-        .source = ev->source,
-        #endif
-    };
-
-    zmk_behavior_invoke_binding(&kp_binding, event, false);
-    active_dead_key.is_down = false;
-
+  struct zmk_position_state_changed *ev = as_zmk_position_state_changed(eh);
+  if (ev == NULL || !active_dead_key.is_down) {
     return ZMK_EV_EVENT_BUBBLE;
+  }
+
+  struct zmk_behavior_binding kp_binding = {
+    .behavior_dev = "key_press",
+    .param1 = active_dead_key.dead_keycode,
+  };
+
+  struct zmk_behavior_binding_event event = {
+    .position = active_dead_key.position,
+    .timestamp = ev->timestamp,
+    #if IS_ENABLED(CONFIG_ZMK_SPLIT)
+    .source = ev->source,
+    #endif
+  };
+
+  zmk_behavior_invoke_binding(&kp_binding, event, false);
+  active_dead_key.is_down = false;
+
+  return ZMK_EV_EVENT_BUBBLE;
 }
 
-#define DEAD_KEY_INST(n)                                                      \
-    static struct behavior_dead_key_config behavior_dead_key_config_##n = {   \
-        .dead_keycode = DT_INST_PROP(n, dead_keycode)                         \
-    };                                                                        \
-                                                                              \
-    BEHAVIOR_DT_INST_DEFINE(                                                  \
-        n,     /* Instance Number (Automatically populated by macro) */       \
-        NULL,  /* Initialization Function */                                  \
-        NULL,  /* Power Management Device Pointer */                          \
-        NULL,  /* Behavior Data Pointer */                                    \
-        &behavior_dead_key_config_##n,  /* Behavior Configuration Pointer */  \
-        POST_KERNEL,  /* Initialization Level */                              \
-        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,  /* Device Priority */           \
-        &dead_key_driver_api);  // API struct
+#define DEAD_KEY_INST(n)                                                  \
+  static struct behavior_dead_key_config behavior_dead_key_config_##n = {   \
+    .dead_keycode = DT_INST_PROP(n, dead_keycode)                           \
+  };                                                                        \
+                                                                            \
+  BEHAVIOR_DT_INST_DEFINE(                                                  \
+    n,     /* Instance Number (Automatically populated by macro) */         \
+    NULL,  /* Initialization Function */                                    \
+    NULL,  /* Power Management Device Pointer */                            \
+    NULL,  /* Behavior Data Pointer */                                      \
+    &behavior_dead_key_config_##n,  /* Behavior Configuration Pointer */    \
+    POST_KERNEL,  /* Initialization Level */                                \
+    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,  /* Device Priority */             \
+    &dead_key_driver_api);  // API struct
 
 DT_INST_FOREACH_STATUS_OKAY(DEAD_KEY_INST)
 

--- a/src/behaviors/behavior_dead_key.c
+++ b/src/behaviors/behavior_dead_key.c
@@ -21,71 +21,71 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
 
 struct behavior_dead_key_config {
-  uint32_t dead_keycode;
+    uint32_t dead_keycode;
 };
 
 struct behavior_dead_key_data {
-  uint32_t position;
-  uint32_t dead_keycode;
-  bool is_down;
+    uint32_t position;
+    uint32_t dead_keycode;
+    bool is_down;
 };
 
 static struct behavior_dead_key_data active_dead_key;
 
 static int on_dead_key_binding_pressed(
-  struct zmk_behavior_binding *binding,
-  struct zmk_behavior_binding_event event
+    struct zmk_behavior_binding *binding,
+    struct zmk_behavior_binding_event event
 ) {
-  const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
-  const struct behavior_dead_key_config *cfg = dev->config;
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    const struct behavior_dead_key_config *cfg = dev->config;
 
-  struct zmk_behavior_binding kp_binding = {
-    .behavior_dev = "key_press",
-    .param1 = cfg->dead_keycode,
-  };
+    struct zmk_behavior_binding kp_binding = {
+        .behavior_dev = "key_press",
+        .param1 = cfg->dead_keycode,
+    };
 
-  const zmk_mod_flags_t mods_before = zmk_hid_get_explicit_mods();
-  zmk_hid_masked_modifiers_set(MOD_LSFT | MOD_RSFT);
-  zmk_behavior_invoke_binding(&kp_binding, event, true);
-  zmk_hid_masked_modifiers_clear();
+    const zmk_mod_flags_t mods_before = zmk_hid_get_explicit_mods();
+    zmk_hid_masked_modifiers_set(MOD_LSFT | MOD_RSFT);
+    zmk_behavior_invoke_binding(&kp_binding, event, true);
+    zmk_hid_masked_modifiers_clear();
 
-  active_dead_key = (struct behavior_dead_key_data) {
-    .position = event.position,
-    .dead_keycode = cfg->dead_keycode,
-    .is_down = true,
-  };
+    active_dead_key = (struct behavior_dead_key_data) {
+        .position = event.position,
+        .dead_keycode = cfg->dead_keycode,
+        .is_down = true,
+    };
 
-  const zmk_mod_flags_t mods_after = zmk_hid_get_explicit_mods();
-  const zmk_mod_flags_t sticky_mods = mods_before ^ mods_after;
-  kp_binding.param1 = APPLY_MODS(sticky_mods, binding->param1);
-  zmk_behavior_invoke_binding(&kp_binding, event, true);
+    const zmk_mod_flags_t mods_after = zmk_hid_get_explicit_mods();
+    const zmk_mod_flags_t sticky_mods = mods_before ^ mods_after;
+    kp_binding.param1 = APPLY_MODS(sticky_mods, binding->param1);
+    zmk_behavior_invoke_binding(&kp_binding, event, true);
 
-  return ZMK_BEHAVIOR_OPAQUE;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static int on_dead_key_binding_released(
-  struct zmk_behavior_binding *binding,
-  struct zmk_behavior_binding_event event
+    struct zmk_behavior_binding *binding,
+    struct zmk_behavior_binding_event event
 ) {
-  struct zmk_behavior_binding kp_binding = {
-    .behavior_dev = "key_press",
-    .param1 = active_dead_key.dead_keycode,
-  };
+    struct zmk_behavior_binding kp_binding = {
+        .behavior_dev = "key_press",
+        .param1 = active_dead_key.dead_keycode,
+    };
 
-  if (active_dead_key.is_down) {
-    active_dead_key.is_down = false;
+    if (active_dead_key.is_down) {
+        active_dead_key.is_down = false;
+        zmk_behavior_invoke_binding(&kp_binding, event, false);
+    };
+
+    kp_binding.param1 = binding->param1;
     zmk_behavior_invoke_binding(&kp_binding, event, false);
-  };
 
-  kp_binding.param1 = binding->param1;
-  zmk_behavior_invoke_binding(&kp_binding, event, false);
-
-  return ZMK_BEHAVIOR_OPAQUE;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static const struct behavior_driver_api dead_key_driver_api = {
-  .binding_pressed  = on_dead_key_binding_pressed,
-  .binding_released = on_dead_key_binding_released,
+    .binding_pressed  = on_dead_key_binding_pressed,
+    .binding_released = on_dead_key_binding_released,
 };
 
 static int dead_key_position_state_changed_listener(const zmk_event_t *eh);
@@ -94,44 +94,44 @@ ZMK_LISTENER(behavior_dead_key, dead_key_position_state_changed_listener);
 ZMK_SUBSCRIPTION(behavior_dead_key, zmk_position_state_changed);
 
 static int dead_key_position_state_changed_listener(const zmk_event_t *eh) {
-  struct zmk_position_state_changed *ev = as_zmk_position_state_changed(eh);
-  if (ev == NULL || !active_dead_key.is_down) {
+    struct zmk_position_state_changed *ev = as_zmk_position_state_changed(eh);
+    if (ev == NULL || !active_dead_key.is_down) {
+        return ZMK_EV_EVENT_BUBBLE;
+    }
+
+    struct zmk_behavior_binding kp_binding = {
+        .behavior_dev = "key_press",
+        .param1 = active_dead_key.dead_keycode,
+    };
+
+    struct zmk_behavior_binding_event event = {
+        .position = active_dead_key.position,
+        .timestamp = ev->timestamp,
+        #if IS_ENABLED(CONFIG_ZMK_SPLIT)
+        .source = ev->source,
+        #endif
+    };
+
+    zmk_behavior_invoke_binding(&kp_binding, event, false);
+    active_dead_key.is_down = false;
+
     return ZMK_EV_EVENT_BUBBLE;
-  }
-
-  struct zmk_behavior_binding kp_binding = {
-    .behavior_dev = "key_press",
-    .param1 = active_dead_key.dead_keycode,
-  };
-
-  struct zmk_behavior_binding_event event = {
-    .position = active_dead_key.position,
-    .timestamp = ev->timestamp,
-    #if IS_ENABLED(CONFIG_ZMK_SPLIT)
-    .source = ev->source,
-    #endif
-  };
-
-  zmk_behavior_invoke_binding(&kp_binding, event, false);
-  active_dead_key.is_down = false;
-
-  return ZMK_EV_EVENT_BUBBLE;
 }
 
-#define DEAD_KEY_INST(n)                                                  \
-  static struct behavior_dead_key_config behavior_dead_key_config_##n = {   \
-    .dead_keycode = DT_INST_PROP(n, dead_keycode)                           \
-  };                                                                        \
-                                                                            \
-  BEHAVIOR_DT_INST_DEFINE(                                                  \
-    n,     /* Instance Number (Automatically populated by macro) */         \
-    NULL,  /* Initialization Function */                                    \
-    NULL,  /* Power Management Device Pointer */                            \
-    NULL,  /* Behavior Data Pointer */                                      \
-    &behavior_dead_key_config_##n,  /* Behavior Configuration Pointer */    \
-    POST_KERNEL,  /* Initialization Level */                                \
-    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,  /* Device Priority */             \
-    &dead_key_driver_api);  // API struct
+#define DEAD_KEY_INST(n)                                                      \
+    static struct behavior_dead_key_config behavior_dead_key_config_##n = {   \
+        .dead_keycode = DT_INST_PROP(n, dead_keycode)                         \
+    };                                                                        \
+                                                                              \
+    BEHAVIOR_DT_INST_DEFINE(                                                  \
+        n,     /* Instance Number (Automatically populated by macro) */       \
+        NULL,  /* Initialization Function */                                  \
+        NULL,  /* Power Management Device Pointer */                          \
+        NULL,  /* Behavior Data Pointer */                                    \
+        &behavior_dead_key_config_##n,  /* Behavior Configuration Pointer */  \
+        POST_KERNEL,  /* Initialization Level */                              \
+        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,  /* Device Priority */           \
+        &dead_key_driver_api);  // API struct
 
 DT_INST_FOREACH_STATUS_OKAY(DEAD_KEY_INST)
 

--- a/src/behaviors/behavior_dead_key.c
+++ b/src/behaviors/behavior_dead_key.c
@@ -1,8 +1,8 @@
 /*
  * Dead Key Behavior
- * prefix a key press with an unshifted-keycode, to more easilly and reliably
- * use dead keys on the host layout to write more complex symbols.
- */
+ * Press a non-modified dead key before the target key.
+ * This ensures the dead key is always applied without any modifier, even if
+ * Shift or Ctrl or Cmd are pressed while the target key is tapped.
 
 #define DT_DRV_COMPAT zmk_behavior_dead_key
 

--- a/src/behaviors/behavior_dead_key.c
+++ b/src/behaviors/behavior_dead_key.c
@@ -45,7 +45,7 @@ static int on_dead_key_binding_pressed(
     };
 
     const zmk_mod_flags_t mods_before = zmk_hid_get_explicit_mods();
-    zmk_hid_masked_modifiers_set(MOD_LSFT | MOD_RSFT);
+    zmk_hid_masked_modifiers_set(0xff);  /* Temporarily disable any active modifier */
     zmk_behavior_invoke_binding(&kp_binding, event, true);
     zmk_hid_masked_modifiers_clear();
 
@@ -131,7 +131,7 @@ static int dead_key_position_state_changed_listener(const zmk_event_t *eh) {
         &behavior_dead_key_config_##n,  /* Behavior Configuration Pointer */  \
         POST_KERNEL,  /* Initialization Level */                              \
         CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,  /* Device Priority */           \
-        &dead_key_driver_api);  // API struct
+        &dead_key_driver_api);  /* API struct */
 
 DT_INST_FOREACH_STATUS_OKAY(DEAD_KEY_INST)
 

--- a/src/behaviors/behavior_dead_key.c
+++ b/src/behaviors/behavior_dead_key.c
@@ -1,6 +1,6 @@
 /*
  * Dead Key Behavior
- * Press a non-modified dead key before the target key.
+ * Tap a non-modified dead key before the target key.
  * This ensures the dead key is always applied without any modifier, even if
  * Shift or Ctrl or Cmd are pressed while the target key is tapped.
  */

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,7 @@
 build:
+  cmake: .
+  kconfig: Kconfig
   settings:
     board_root: .
+    dts_root: .
+    snippet_root: .


### PR DESCRIPTION
This patch adds the necessary framework needed to add custom behaviors in the project (cmake list, kconfig, and everything under `dts` or `src`) along with a custom behavior : `dead-key`.

It’s used in basically the same way as the `DEAD_KEY(name, key)` macros we had before, but has a couple of advantages : 

- The dead keycode is unshifted, so no risk of getting `!S` when trying to type `É` in Ergo‑L ;
- One-shot shift is correctly detected and reapplied to the key specified as argument, while the old macro would only apply it to the dead keycode ;

This means we don’t need to have another layer just for the dead-key + shift, and avoids the timing / locking issues we had with the simple macros.