### PR TITLE
add instruction to ensure that the zephyr SDK is in the zmk directory instead of $HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ west update  # this installs Zephyr and other ZMK stuff (takes a while)
 cd zephyr
 uv pip install -r scripts/requirements-base.txt
 uv pip install protobuf grpcio-tools
-west sdk install  # (this takes a while)
+west sdk install -b ../ # (this takes a while) | -b ../ will install zephyr sdk in the zmk directory instead of $HOME
 ```
 
 When done, symlink the ZMK folder in the local `zmk-keyboard-quacken` folder,

--- a/README.md
+++ b/README.md
@@ -82,7 +82,15 @@ west update  # this installs Zephyr and other ZMK stuff (takes a while)
 cd zephyr
 uv pip install -r scripts/requirements-base.txt
 uv pip install protobuf grpcio-tools
-west sdk install -b ../ # (this takes a while) | -b ../ will install zephyr sdk in the zmk directory instead of $HOME
+west sdk install -b .. # (this takes a while)
+```
+
+The last line will install the SDK directly in the ZMK directory.
+As this SDK takes about 10 GB of disk space, if you want to
+reuse it easily across projects, you might prefer to install it
+in your $HOME directory instead, like this:
+```
+west sdk install
 ```
 
 When done, symlink the ZMK folder in the local `zmk-keyboard-quacken` folder,


### PR DESCRIPTION
adding in the README the `-b` option to the zephyr sdk install to keep it in the zmk directory instead of $HOME