### PR TITLE
fix(azerty): double dead key

### DIFF
--- a/keymaps/aliases/azerty.h
+++ b/keymaps/aliases/azerty.h
@@ -92,7 +92,8 @@
   #define C_NTLD &digraph RA(N2) N // ñ
 #endif
 
-#define C_MU &kp PIPE // µ
+#define C_MU   &kp PIPE  // µ
+#define C_EURO &kp RA(E) // €
 
 // circumflex accent
 #define C_ACRC &digraph LBKT Q // â

--- a/keymaps/extra_layers/azerty.dtsi
+++ b/keymaps/extra_layers/azerty.dtsi
@@ -13,17 +13,7 @@
 
 / {
   behaviors {
-    dead_key: dead_key {
-      compatible = "zmk,behavior-mod-morph";
-      #binding-cells = <0>;
-      bindings = <&EZ_SL(DK_LAYER)>, <&kp SQT>;
-      mods      = <(MOD_LSFT|MOD_RSFT)>;
-      keep-mods = <(MOD_LSFT|MOD_RSFT)>;
-    };
-  };
-
-  macros {
-    DEAD_KEY(kpc, &kp LBKT)  // circumflex accent
+    TWO_LEVEL_KEY(dead_key, &EZ_SL(DK_LAYER), S_PRCNT) // ' % (1dk)
   };
 
   // Extra layers defined specifically for this keymap, appended to the base keymap.
@@ -31,12 +21,12 @@
     compatible = "zmk,keymap";
 
     dead_key_layer {
-      display-name = "DeadKey";
+      display-name = "1dk";
       bindings = <
-        &trans    &kp N0  &kp N2  &kp N7  &kp RA(E) &trans     &trans  &kp SQT &trans  &trans  &trans       &trans
-        &trans    &kpc Q  &trans  &kpc E  &kp N6  &kp N8       &trans  &kpc U  &kpc I  &kpc O  &trans       &trans
-        &trans    &trans  &trans  &kp N9  &kp N5  &kp MINUS    &trans  &trans  &trans  &trans  &kp LS(FSLH) &kp LS(LBKT)
-                                  &trans  &kp N4  &trans       &trans  &kp N4  &trans
+        &trans  C_AGRV  C_EACU  C_EGRV  C_EURO  &trans    &trans  C_UGRV  &trans  C_OE    &trans  &trans
+        &trans  C_ACRC  C_AE    C_ECRC  S_MINUS S_UNDER   &trans  C_UCRC  C_ICRC  C_OCRC  C_MU    &kp LBRC
+        &trans  &trans  &trans  C_CCDL  S_LPAR  S_RPAR    &trans  &trans  &trans  &trans  &trans  &trans
+                                &trans  S_SQT   &trans    &trans  S_SQT   &trans
       >;
     };
   };


### PR DESCRIPTION
The `azerty.dtsi` extra layer was still half-way between the Flex and the Zero, hence the wrong placement of the diaeresis in the 1dk layer.

I’ve updated the dtsi to use the layout-specific symbols while I was at it.